### PR TITLE
Fix device fallback for T5 model

### DIFF
--- a/phantom_wan/modules/t5.py
+++ b/phantom_wan/modules/t5.py
@@ -475,11 +475,13 @@ class T5EncoderModel:
         self,
         text_len,
         dtype=torch.bfloat16,
-        device=torch.cuda.current_device(),
+        device=None,
         checkpoint_path=None,
         tokenizer_path=None,
         shard_fn=None,
     ):
+        if device is None:
+            device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         self.text_len = text_len
         self.dtype = dtype
         self.device = device


### PR DESCRIPTION
## Summary
- handle `None` device in `T5EncoderModel`
- default to CUDA if available else CPU
- maintain model `.to()` behavior

## Testing
- `pytest -q`
- `cog push` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840269c8a2c832d9d03294f34064747